### PR TITLE
rtc_ds1307_low_level.c , pointer for a single byte removed, now uint8_t is directly passed

### DIFF
--- a/rtc_ds1307_low_level.c
+++ b/rtc_ds1307_low_level.c
@@ -2,7 +2,7 @@
 #include "rtc_ds1307.h"
 
 /*function to transmit one byte of data to register_address on ds1307*/
-void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte)
+void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte)
 {
 }
 
@@ -12,7 +12,7 @@ void time_i2c_write_multi(uint8_t device_address, uint8_t start_register_address
 }
 
 /*function to read one byte of data from register_address on ds1307*/
-void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte)
+void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte)
 {
 }
 


### PR DESCRIPTION
```
/*function to transmit one byte of data to register_address on ds1307*/
void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte)
{
}

```
would be

/*function to transmit one byte of data to register_address on ds1307*/
```
void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte)
{
}

```
likewise

```
/*function to read one byte of data from register_address on ds1307*/
void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte)
{
}

```
woould be

```
/*function to read one byte of data from register_address on ds1307*/
void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte)
{
}
```
