### PR TITLE
Update rtc_ds1307.h

### DIFF
--- a/rtc_ds1307.h
+++ b/rtc_ds1307.h
@@ -65,9 +65,9 @@ void DS1307_snapshot_save();
 void DS1307_snapshot_clear();
 
 void DS1307_I2C_init();
-void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte);
+void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte);
 void time_i2c_write_multi(uint8_t device_address, uint8_t start_register_address, uint8_t *data_array, uint8_t data_length);
-void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte);
+void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte);
 void time_i2c_read_multi(uint8_t device_address, uint8_t start_register_address, uint8_t *data_array, uint8_t data_length);
 
 #endif


### PR DESCRIPTION
changes in function which are used internally. Needs pointer in params but prototype had direct uint8_t